### PR TITLE
`triggers` to type + `showTrigger`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# ngx-float-ui  
+# ngx-float-ui
 
 [![npm][badge-npm-version]][url-npm] [![npm][badge-npm-downloads]][url-npm] [![MIT licensed][badge-licence]][url-licence] [![Build state][badge-ci-state]][url-ci-state] [![Size][badge-bundle]][url-bundle] [![Rate this package][badge-openbase]][url-openbase]
 
 ngx-float-ui is an angular wrapper for the [FloatingUI](https://floating-ui.com/) library (v ^1.5.3).
 
 ## VERY IMPORTANT READ THIS
+
 I'm moving this to the top because it appears that people don't get to reading it in the **contribute** section.
 FOR THIS LIBRARY **PLEASE USE ISSUES ONLY FOR BUG REPORTING**. DON'T OPEN ISSUES SUCH AS "I need upgrade for Angular 1745646456" especially if Angular 1745646456 was released a few days ago.
 I **guarantee** that I manage the updates **AS SOON AS POSSIBLE**. But as you understand this is not a paying job, so you can't get Angular 1745646456 the day it gets released.
@@ -21,38 +22,39 @@ node and npm are required to run this package.
 
 1. Use npm/yarn to install the package:
 
-  ```terminal
-  $ npm install @floating-ui/dom ngx-float-ui --save
-  ```
-  
-  Or 
-  
-   ```terminal
-    $ yarn add @floating-ui/dom --save
-    $ yarn add ngx-float-ui --save 
-  ```
+```terminal
+$ npm install @floating-ui/dom ngx-float-ui --save
+```
+
+Or
+
+```terminal
+ $ yarn add @floating-ui/dom --save
+ $ yarn add ngx-float-ui --save
+```
 
 2. You simply add into your module `NgxFloatUiModule`:
 
-  ```typescript
-  import {NgxFloatUiModule} from 'ngx-float-ui';
-  
-  @NgModule({
+```typescript
+import {NgxFloatUiModule} from 'ngx-float-ui';
+
+@NgModule({
+ // ...
+ imports: [
    // ...
-   imports: [
-     // ...
-     NgxFloatUiModule
-   ]
-  })
-  ```
+   NgxFloatUiModule
+ ]
+})
+```
 
 Optionally you can include in your `styles.css` / `styles.css` one of the prebuilt themes:
-* `@import node_modules/ngx-float-ui/css/theme-dark.css`
-* `@import node_modules/css/theme-white.css`
 
-* `@use ngx-float-ui/scss/theme as floatUiBaseTheme`
-* `@use ngx-float-ui/scss/theme-dark as floatUiDarkTheme`
-* `@use ngx-float-ui/scss/theme-white floatUiWhiteTheme`
+- `@import node_modules/ngx-float-ui/css/theme-dark.css`
+- `@import node_modules/css/theme-white.css`
+
+- `@use ngx-float-ui/scss/theme as floatUiBaseTheme`
+- `@use ngx-float-ui/scss/theme-dark as floatUiDarkTheme`
+- `@use ngx-float-ui/scss/theme-white floatUiWhiteTheme`
 
 or easily create your own theme using the @mixin:
 
@@ -66,117 +68,120 @@ body {
 
 3. Add to view:
 
-  ```HTML  
-   <float-ui-content #popper1Content>
-       <p class="bold">Popper on bottom</p>
-   </float-ui-content>
-   <div [floatUi]="popper1Content"
-        [showOnStart]="true"
-        [trigger]="'click'"
+```HTML
+ <float-ui-content #popper1Content>
+     <p class="bold">Popper on bottom</p>
+ </float-ui-content>
+ <div [floatUi]="popper1Content"
+      [showOnStart]="true"
+      [showTrigger]="'click'"
 		hideOnClickOutside
-        [hideOnScroll]="true"
-        [placement]="'bottom'">
-       <p class="bold">Hey!</p>
-       <p class="thin">Choose where to put your popper!</p>         
-   </div>
-  ```
+      [hideOnScroll]="true"
+      [placement]="'bottom'">
+     <p class="bold">Hey!</p>
+     <p class="thin">Choose where to put your popper!</p>
+ </div>
+```
 
 4. As text:
- ```HTML
-      <div floatUi="As text"
-           [trigger]="'hover'"
-           [placement]="'bottom'"
-           (onShown)="onShown($event)">
-        <p class="bold">Pop</p>
-        <p class="thin">on the bottom</p>
-      </div>
- ```
 
-  ```HTML
-       <div floatUi="{{someTextProperty}}"
-            [trigger]="'hover'"
-            [placement]="'bottom'"
-            [styles]="{'background-color: 'blue''}"
-            (onShown)="onShown($event)">
-         <p class="bold">Pop</p>
-         <p class="thin">on the bottom</p>
-       </div>
-  ```
- 
-  5. Position fixed, breaking overflow:
-   ```HTML
-        <div floatUi="As text"
-             [trigger]="'hover'"
-             [placement]="'bottom'"
-             [positionFixed]="true"
-             (onShown)="onShown($event)">
-        </div>
-   ```
- 
- 6. Specific target:
-  ```HTML
- <div class="example">
-       <div #popperTargetElement></div>
-       <div floatUi="As text"
-            trigger="hover"
-            placement="bottom"
-            [target]="popperTargetElement.nativeElement"
-            (onShown)="onShown($event)">
-       </div>
-  ```
-  
+```HTML
+     <div floatUi="As text"
+          [showTrigger]="'hover'"
+          [placement]="'bottom'"
+          (onShown)="onShown($event)">
+       <p class="bold">Pop</p>
+       <p class="thin">on the bottom</p>
+     </div>
+```
+
+```HTML
+     <div floatUi="{{someTextProperty}}"
+          [showTrigger]="'hover'"
+          [placement]="'bottom'"
+          [styles]="{'background-color: 'blue''}"
+          (onShown)="onShown($event)">
+       <p class="bold">Pop</p>
+       <p class="thin">on the bottom</p>
+     </div>
+```
+
+5. Position fixed, breaking overflow:
+
+```HTML
+     <div floatUi="As text"
+          [showTrigger]="'hover'"
+          [placement]="'bottom'"
+          [positionFixed]="true"
+          (onShown)="onShown($event)">
+     </div>
+```
+
+6.  Specific target:
+
+```HTML
+<div class="example">
+     <div #popperTargetElement></div>
+     <div floatUi="As text"
+          showTrigger="hover"
+          placement="bottom"
+          [target]="popperTargetElement.nativeElement"
+          (onShown)="onShown($event)">
+     </div>
+```
+
 7. hide/show programmatically:
-  ```HTML
-   <div [floatUi]="tooltipcontent"
-        trigger="hover"
-        placement="bottom"
-        [applyClass]="'popperSpecialStyle'">
-        <p class="bold">Pop</p>
-        <p class="thin">on the bottom</p>
-      </div>
-      <popper-floatUi #tooltipcontent>
-        <div>
-          <p>This is a tooltip with text</p>
-          <span (click)="tooltipcontent.hide()">Close</span>
-        </div>
-      </popper-floatUi>
-  ```
- 
-8. Attributes map:  
-  
-    | Option             | Type              | Default   | Description                                                                                              |
-    |:-------------------|:----------------  |:--------- | :------------------------------------------------------------------------------------------------------  |
-    | disableAnimation   | boolean           | false     | Disable the default animation on show/hide                                                               |
-    | disableStyle       | boolean           | false     | Disable the default styling                                                                              |
-    | disabled           | boolean           | false     | Disable the popper, ignore all events                                                                    |
-    | delay              | number            | 0         | Delay time until popper it shown                                                                         |
-    | timeout            | number            | 0         | Set delay before the popper is hidden                                                                    |
-    | timeoutAfterShow   | number            | 0         | Set a time on which the popper will be hidden after it is shown                                          |
-    | placement          | Placement(string) | auto      | The placement to show the popper relative to the reference element                                       |
-    | target             | HtmlElement       | auto      | Specify a different reference element other the the one hosting the directive                            |
-    | boundaries         | string(selector)  | undefined | Specify a selector to serve as the boundaries of the element                                             |
-    | showOnStart        | boolean           | false     | Popper default to show                                                                                   |
-    | trigger            | Trigger(string)   | click     | Trigger/Event on which to show/hide the popper                                                           |
-    | positionFixed      | boolean           | false     | Set the popper element to use position: fixed                                                            |
-    | appendTo           | string            | undefined | append The popper-floatUi element to a given selector, if multiple will apply to first                   |
-    | preventOverflow    | boolean           | undefined | Prevent the popper from being positioned outside the boundary                                            |
-    | hideOnClickOutside | boolean           | true      | Popper will hide on a click outside                                                                      |
-    | hideOnScroll       | boolean           | false     | Popper will hide on scroll                                                                               |
-    | hideOnMouseLeave   | boolean           | false     | Popper will hide on mouse leave                                                                          |
-    | applyClass         | string            | undefined | list of comma separated class to apply on ngpx__container                                                |
-    | styles             | Object            | undefined | Apply the styles object, aligned with ngStyles                                                           |
-    | applyArrowClass    | string            | undefined | list of comma separated class to apply on ngpx__arrow                                                    |
-    | onShown            | EventEmitter<>    | $event    | Event handler when popper is shown                                                                       |
-    | onHidden           | EventEmitter<>    | $event    | Event handler when popper is hidden                                                                      |
-    | onUpdate           | EventEmitter<>    | $event    | Event handler when popper is updated                                                                     |
-    | ariaDescribeBy     | string            | undefined | Define value for aria-describeby attribute                                                               |
-    | ariaRole           | string            | popper    | Define value for aria-role attribute                                                                     |
 
+```HTML
+ <div [floatUi]="tooltipcontent"
+      showTrigger="hover"
+      placement="bottom"
+      [applyClass]="'popperSpecialStyle'">
+      <p class="bold">Pop</p>
+      <p class="thin">on the bottom</p>
+    </div>
+    <popper-floatUi #tooltipcontent>
+      <div>
+        <p>This is a tooltip with text</p>
+        <span (click)="tooltipcontent.hide()">Close</span>
+      </div>
+    </popper-floatUi>
+```
+
+8. Attributes map:
+
+   | Option             | Type              | Default   | Description                                                                            |
+   | :----------------- | :---------------- | :-------- | :------------------------------------------------------------------------------------- |
+   | disableAnimation   | boolean           | false     | Disable the default animation on show/hide                                             |
+   | disableStyle       | boolean           | false     | Disable the default styling                                                            |
+   | disabled           | boolean           | false     | Disable the popper, ignore all events                                                  |
+   | delay              | number            | 0         | Delay time until popper it shown                                                       |
+   | timeout            | number            | 0         | Set delay before the popper is hidden                                                  |
+   | timeoutAfterShow   | number            | 0         | Set a time on which the popper will be hidden after it is shown                        |
+   | placement          | Placement(string) | auto      | The placement to show the popper relative to the reference element                     |
+   | target             | HtmlElement       | auto      | Specify a different reference element other the the one hosting the directive          |
+   | boundaries         | string(selector)  | undefined | Specify a selector to serve as the boundaries of the element                           |
+   | showOnStart        | boolean           | false     | Popper default to show                                                                 |
+   | showTrigger        | Trigger(string)   | click     | Trigger/Event on which to show/hide the popper                                         |
+   | positionFixed      | boolean           | false     | Set the popper element to use position: fixed                                          |
+   | appendTo           | string            | undefined | append The popper-floatUi element to a given selector, if multiple will apply to first |
+   | preventOverflow    | boolean           | undefined | Prevent the popper from being positioned outside the boundary                          |
+   | hideOnClickOutside | boolean           | true      | Popper will hide on a click outside                                                    |
+   | hideOnScroll       | boolean           | false     | Popper will hide on scroll                                                             |
+   | hideOnMouseLeave   | boolean           | false     | Popper will hide on mouse leave                                                        |
+   | applyClass         | string            | undefined | list of comma separated class to apply on ngpx\_\_container                            |
+   | styles             | Object            | undefined | Apply the styles object, aligned with ngStyles                                         |
+   | applyArrowClass    | string            | undefined | list of comma separated class to apply on ngpx\_\_arrow                                |
+   | onShown            | EventEmitter<>    | $event    | Event handler when popper is shown                                                     |
+   | onHidden           | EventEmitter<>    | $event    | Event handler when popper is hidden                                                    |
+   | onUpdate           | EventEmitter<>    | $event    | Event handler when popper is updated                                                   |
+   | ariaDescribeBy     | string            | undefined | Define value for aria-describeby attribute                                             |
+   | ariaRole           | string            | popper    | Define value for aria-role attribute                                                   |
 
 9. Override defaults:
 
-    ngx-float-ui comes with a few default properties you can override in default to effect all instances
-    These are overridden by any child attributes.
+   ngx-float-ui comes with a few default properties you can override in default to effect all instances
+   These are overridden by any child attributes.
 
 ```JavaScript
 NgModule({
@@ -190,59 +195,60 @@ NgModule({
 
 });
 ```
-  
-   | Options               | Type              | Default   |
-   |:----------------------|:------------------|:----------|
-   | showDelay             | number            | 0         |
-   | disableAnimation      | boolean           | false     |
-   | disableDefaultStyling | boolean           | false     |
-   | placement             | Placement(string) | auto      |
-   | boundariesElement     | string(selector)  | undefined |
-   | trigger               | Trigger(string)   | hover     |
-   | positionFixed         | boolean           | false     |
-   | hideOnClickOutside    | boolean           | true      |
-   | hideOnMouseLeave      | boolean           | false     |
-   | hideOnScroll          | boolean           | false     |
-   | applyClass            | string            | undefined |
-   | styles                | Object            | undefined |
-   | applyArrowClass       | string            | undefined |
-   | ariaDescribeBy        | string            | undefined |
-   | ariaRole              | string            | undefined |
-   | appendTo              | string            | undefined |
-   | preventOverflow       | boolean           | undefined |
+
+| Options               | Type              | Default   |
+| :-------------------- | :---------------- | :-------- |
+| showDelay             | number            | 0         |
+| disableAnimation      | boolean           | false     |
+| disableDefaultStyling | boolean           | false     |
+| placement             | Placement(string) | auto      |
+| boundariesElement     | string(selector)  | undefined |
+| showTrigger           | Trigger(string)   | click     |
+| positionFixed         | boolean           | false     |
+| hideOnClickOutside    | boolean           | true      |
+| hideOnMouseLeave      | boolean           | false     |
+| hideOnScroll          | boolean           | false     |
+| applyClass            | string            | undefined |
+| styles                | Object            | undefined |
+| applyArrowClass       | string            | undefined |
+| ariaDescribeBy        | string            | undefined |
+| ariaRole              | string            | undefined |
+| appendTo              | string            | undefined |
+| preventOverflow       | boolean           | undefined |
 
 10. NgxFloatUiPopPlacements:
 
-  | 'top'
-  | 'bottom'
-  | 'left'
-  | 'right'
-  | 'top-start'
-  | 'bottom-start'
-  | 'left-start'
-  | 'right-start'
-  | 'top-end'
-  | 'bottom-end'
-  | 'left-end'
-  | 'right-end'
-  | 'auto'
-  | 'auto-start'
-  | 'auto-end'
-  
+| 'top'
+| 'bottom'
+| 'left'
+| 'right'
+| 'top-start'
+| 'bottom-start'
+| 'left-start'
+| 'right-start'
+| 'top-end'
+| 'bottom-end'
+| 'left-end'
+| 'right-end'
+| 'auto'
+| 'auto-start'
+| 'auto-end'
+
 11. NgxFloatUiTriggers:
 
-  | 'click'
-  | 'mousedown'
-  | 'hover'
-  | 'none'
-  
-    
+| 'click'
+| 'mousedown'
+| 'hover'
+| 'none'
+
 ### Demo site with sample codes
+
 <a href="https://tonysamperi.github.io/ngx-float-ui/">Demo of ngx-float-ui</a>
 
 ### Contribute
-  You can only **report bugs**. Every other issue will be deleted right away.
-  
+
+You can only **report bugs**. Every other issue will be deleted right away.
+
 ```terminal
   $ npm install
   $ npm run start  //run example

--- a/projects/ngx-float-ui/src/lib/components/ngx-float-ui-content/ngx-float-ui-content.component.ts
+++ b/projects/ngx-float-ui/src/lib/components/ngx-float-ui-content/ngx-float-ui-content.component.ts
@@ -1,264 +1,299 @@
 import {
-    ChangeDetectionStrategy,
-    ChangeDetectorRef,
-    Component,
-    ElementRef,
-    EventEmitter,
-    HostListener,
-    OnDestroy,
-    ViewChild,
-    ViewContainerRef,
-    ViewEncapsulation
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  OnDestroy,
+  ViewChild,
+  ViewContainerRef,
+  ViewEncapsulation,
 } from "@angular/core";
 import {NgStyle, NgClass, NgIf} from "@angular/common";
 //
 import {NgxFloatUiOptions} from "../../models/ngx-float-ui-options.model";
-import {NgxFloatUiTriggers} from "../../models/ngx-float-ui-triggers.model";
 //
 import {
-    computePosition,
-    autoUpdate,
-    flip,
-    arrow,
-    limitShift,
-    shift,
-    offset,
-    autoPlacement,
-    ComputePositionConfig
+  computePosition,
+  autoUpdate,
+  flip,
+  arrow,
+  limitShift,
+  shift,
+  offset,
+  autoPlacement,
+  ComputePositionConfig,
 } from "@floating-ui/dom";
 import {fromEvent, Subject, takeUntil} from "rxjs";
 
 @Component({
-    selector: "float-ui-content",
-    encapsulation: ViewEncapsulation.None,
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    templateUrl: "./ngx-float-ui-content.component.html",
-    styleUrls: ["./ngx-float-ui-content.component.scss"],
-    exportAs: "ngxFloatUiContent",
-    standalone: true,
-    imports: [NgStyle, NgClass, NgIf]
+  selector: "float-ui-content",
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: "./ngx-float-ui-content.component.html",
+  styleUrls: ["./ngx-float-ui-content.component.scss"],
+  exportAs: "ngxFloatUiContent",
+  standalone: true,
+  imports: [NgStyle, NgClass, NgIf],
 })
 export class NgxFloatUiContentComponent implements OnDestroy {
+  static nextId: number = 0;
 
-    static nextId: number = 0;
+  ariaHidden: string;
+  arrowColor: string | null = null;
+  displayType: string;
+  floatUiOptions: NgxFloatUiOptions = {
+    disableAnimation: false,
+    disableDefaultStyling: false,
+    boundariesElement: "",
+    showTrigger: "hover",
+    positionFixed: false,
+    appendToBody: false,
+    popperModifiers: [],
+  } as NgxFloatUiOptions;
+  floatUiSwitch: () => void;
+  @ViewChild("floatUiViewRef", {static: !0}) floatUiViewRef: ElementRef;
+  id: string = `ngx_float_ui_${++NgxFloatUiContentComponent.nextId}`;
+  isMouseOver: boolean = !1;
+  onHidden = new EventEmitter();
+  onUpdate: () => any;
+  opacity: number;
+  referenceObject: HTMLElement;
+  state: boolean;
+  text: string;
 
-    ariaHidden: string;
-    arrowColor: string | null = null;
-    displayType: string;
-    floatUiOptions: NgxFloatUiOptions = {
-        disableAnimation: false,
-        disableDefaultStyling: false,
-        boundariesElement: "",
-        trigger: NgxFloatUiTriggers.hover,
-        positionFixed: false,
-        appendToBody: false,
-        popperModifiers: []
-    } as NgxFloatUiOptions;
-    floatUiSwitch: () => void;
-    @ViewChild("floatUiViewRef", {static: !0}) floatUiViewRef: ElementRef;
-    id: string = `ngx_float_ui_${++NgxFloatUiContentComponent.nextId}`;
-    isMouseOver: boolean = !1;
-    onHidden = new EventEmitter();
-    onUpdate: () => any;
-    opacity: number;
-    referenceObject: HTMLElement;
-    state: boolean;
-    text: string;
+  protected _destroy$: Subject<void> = new Subject<void>();
+  protected _resizeCtrl$: Subject<void> = new Subject<void>();
+  protected _styleId = `${this.id}_style`;
 
-    protected _destroy$: Subject<void> = new Subject<void>();
-    protected _resizeCtrl$: Subject<void> = new Subject<void>();
-    protected _styleId = `${this.id}_style`;
+  constructor(
+    public elRef: ElementRef,
+    protected _viewRef: ViewContainerRef,
+    protected _changeDetectorRef: ChangeDetectorRef
+  ) {
+    this._toggleVisibility(!1);
+  }
 
-    constructor(public elRef: ElementRef,
-                protected _viewRef: ViewContainerRef,
-                protected _changeDetectorRef: ChangeDetectorRef) {
-        this._toggleVisibility(!1);
+  clean() {
+    this.toggleVisibility(false);
+    if (!this.floatUiSwitch) {
+      return;
     }
+    this.floatUiSwitch();
+  }
 
-    clean() {
-        this.toggleVisibility(false);
-        if (!this.floatUiSwitch) {
-            return;
-        }
-        this.floatUiSwitch();
+  extractAppliedClassListExpr(classList: string | string[] = []): object {
+    const klassList = Array.isArray(classList)
+      ? classList
+      : typeof classList === typeof ""
+      ? classList.replace(/ /, "").split(",")
+      : [];
+
+    return klassList.reduce((acc, klass) => {
+      acc[klass] = !0;
+
+      return acc;
+    }, {});
+  }
+
+  hide(): void {
+    if (this.floatUiSwitch) {
+      this.floatUiSwitch();
     }
+    this.toggleVisibility(!1);
+    this.onHidden.emit();
+  }
 
-    extractAppliedClassListExpr(classList: string | string[] = []): object {
-        const klassList = Array.isArray(classList) ? classList : typeof classList === typeof "" ? classList.replace(/ /, "").split(",") : [];
-
-        return klassList.reduce((acc, klass) => {
-            acc[klass] = !0;
-
-            return acc;
-        }, {});
+  ngOnDestroy() {
+    this._destroy$.next();
+    this.clean();
+    if (
+      this.floatUiOptions.appendTo &&
+      this.elRef &&
+      this.elRef.nativeElement &&
+      this.elRef.nativeElement.parentNode
+    ) {
+      this._viewRef.detach();
+      this.elRef.nativeElement.parentNode.removeChild(this.elRef.nativeElement);
     }
+  }
 
-    hide(): void {
-        if (this.floatUiSwitch) {
-            this.floatUiSwitch();
-        }
-        this.toggleVisibility(!1);
-        this.onHidden.emit();
+  onDocumentResize() {
+    this.update();
+  }
+
+  @HostListener("mouseover")
+  onMouseOver() {
+    this.isMouseOver = true;
+  }
+
+  show(): void {
+    if (!this.referenceObject) {
+      return;
     }
-
-    ngOnDestroy() {
-        this._destroy$.next();
-        this.clean();
-        if (this.floatUiOptions.appendTo && this.elRef && this.elRef.nativeElement && this.elRef.nativeElement.parentNode) {
-            this._viewRef.detach();
-            this.elRef.nativeElement.parentNode.removeChild(this.elRef.nativeElement);
-        }
-    }
-
-    onDocumentResize() {
-        this.update();
-    }
-
-    @HostListener("mouseover")
-    onMouseOver() {
-        this.isMouseOver = true;
-    }
-
-    show(): void {
-        if (!this.referenceObject) {
-            return;
-        }
-        this._resizeCtrl$.next();
-        this._determineArrowColor();
-        this.floatUiSwitch = autoUpdate(
-            this.referenceObject,
-            this.floatUiViewRef.nativeElement,
-            () => {
-                this._computePosition();
-            }
-        );
-        fromEvent(document, "resize")
-            .pipe(
-                takeUntil(this._resizeCtrl$),
-                takeUntil(this._destroy$)
-            )
-            .subscribe({
-                next: () => this.onDocumentResize()
-            });
-    }
-
-    @HostListener("mouseleave")
-    showOnLeave() {
-        this.isMouseOver = false;
-        if (this.floatUiOptions.trigger !== NgxFloatUiTriggers.hover && !this.floatUiOptions.hideOnMouseLeave) {
-            return;
-        }
-        this.hide();
-    }
-
-    // Toggle visibility and detect changes - Run only after ngOnInit!
-    toggleVisibility(state: boolean): void {
-        this._toggleVisibility(state);
-        // tslint:disable-next-line:no-string-literal
-        if (!this._changeDetectorRef["destroyed"]) {
-            this._changeDetectorRef.detectChanges();
-        }
-    }
-
-    update(): void {
+    this._resizeCtrl$.next();
+    this._determineArrowColor();
+    this.floatUiSwitch = autoUpdate(
+      this.referenceObject,
+      this.floatUiViewRef.nativeElement,
+      () => {
         this._computePosition();
+      }
+    );
+    fromEvent(document, "resize")
+      .pipe(takeUntil(this._resizeCtrl$), takeUntil(this._destroy$))
+      .subscribe({
+        next: () => this.onDocumentResize(),
+      });
+  }
+
+  @HostListener("mouseleave")
+  showOnLeave() {
+    this.isMouseOver = false;
+    if (
+      this.floatUiOptions.showTrigger !== "hover" &&
+      !this.floatUiOptions.hideOnMouseLeave
+    ) {
+      return;
+    }
+    this.hide();
+  }
+
+  // Toggle visibility and detect changes - Run only after ngOnInit!
+  toggleVisibility(state: boolean): void {
+    this._toggleVisibility(state);
+    // tslint:disable-next-line:no-string-literal
+    if (!this._changeDetectorRef["destroyed"]) {
+      this._changeDetectorRef.detectChanges();
+    }
+  }
+
+  update(): void {
+    this._computePosition();
+  }
+
+  protected _computePosition(): void {
+    const appendToParent =
+      this.floatUiOptions.appendTo &&
+      document.querySelector(this.floatUiOptions.appendTo);
+    if (
+      appendToParent &&
+      this.elRef.nativeElement.parentNode !== appendToParent
+    ) {
+      this.elRef.nativeElement.parentNode &&
+        this.elRef.nativeElement.parentNode.removeChild(
+          this.elRef.nativeElement
+        );
+      appendToParent.appendChild(this.elRef.nativeElement);
     }
 
-    protected _computePosition(): void {
-        const appendToParent = this.floatUiOptions.appendTo && document.querySelector(this.floatUiOptions.appendTo);
-        if (appendToParent && this.elRef.nativeElement.parentNode !== appendToParent) {
-            this.elRef.nativeElement.parentNode && this.elRef.nativeElement.parentNode.removeChild(this.elRef.nativeElement);
-            appendToParent.appendChild(this.elRef.nativeElement);
-        }
-
-        const arrowElement = this.elRef.nativeElement.querySelector(".float-ui-arrow");
-        const arrowLen = arrowElement.offsetWidth;
-        // Get half the arrow box's hypotenuse length
-        const floatingOffset = Math.sqrt(2 * arrowLen ** 2) / 2;
-        const popperOptions: Partial<ComputePositionConfig> = {
-            placement: this.floatUiOptions.placement,
-            strategy: this.floatUiOptions.positionFixed ? "fixed" : "absolute",
-            middleware: [
-                offset(floatingOffset),
-                ...(this.floatUiOptions.preventOverflow ? [flip(), shift({limiter: limitShift()})] : [shift({limiter: limitShift()})]),
-                arrow({
-                    element: arrowElement,
-                    padding: 4
-                })
-            ]
-        };
-        if (!this.floatUiOptions.preventOverflow && !popperOptions.placement) {
-            const boundariesElement = this.floatUiOptions.boundariesElement && document.querySelector(this.floatUiOptions.boundariesElement);
-            popperOptions.middleware.push(
-                autoPlacement({
-                    boundary: boundariesElement
-                })
-            );
-        }
-        computePosition(this.referenceObject, this.floatUiViewRef.nativeElement, popperOptions)
-            .then(({middlewareData, x, y, placement}) => {
-                const side = placement.split("-")[0];
-                this.floatUiViewRef.nativeElement.setAttribute("data-float-ui-placement", side);
-                if (middlewareData.arrow) {
-                    const staticSide = {
-                        top: "bottom",
-                        right: "left",
-                        bottom: "top",
-                        left: "right"
-                    }[side];
-                    Object.assign(arrowElement.style, {
-                        left: middlewareData.arrow.x != null ? `${middlewareData.arrow.x}px` : "",
-                        top: middlewareData.arrow.y != null ? `${middlewareData.arrow.y}px` : "",
-                        [staticSide]: `${-arrowLen / 2}px`
-                    });
-                }
-                Object.assign(this.floatUiViewRef.nativeElement.style, {
-                    left: `${x}px`,
-                    top: `${y}px`
-                });
-                this.toggleVisibility(!0);
-                this.onUpdate?.();
-            });
+    const arrowElement =
+      this.elRef.nativeElement.querySelector(".float-ui-arrow");
+    const arrowLen = arrowElement.offsetWidth;
+    // Get half the arrow box's hypotenuse length
+    const floatingOffset = Math.sqrt(2 * arrowLen ** 2) / 2;
+    const popperOptions: Partial<ComputePositionConfig> = {
+      placement: this.floatUiOptions.placement,
+      strategy: this.floatUiOptions.positionFixed ? "fixed" : "absolute",
+      middleware: [
+        offset(floatingOffset),
+        ...(this.floatUiOptions.preventOverflow
+          ? [flip(), shift({limiter: limitShift()})]
+          : [shift({limiter: limitShift()})]),
+        arrow({
+          element: arrowElement,
+          padding: 4,
+        }),
+      ],
+    };
+    if (!this.floatUiOptions.preventOverflow && !popperOptions.placement) {
+      const boundariesElement =
+        this.floatUiOptions.boundariesElement &&
+        document.querySelector(this.floatUiOptions.boundariesElement);
+      popperOptions.middleware.push(
+        autoPlacement({
+          boundary: boundariesElement,
+        })
+      );
     }
+    computePosition(
+      this.referenceObject,
+      this.floatUiViewRef.nativeElement,
+      popperOptions
+    ).then(({middlewareData, x, y, placement}) => {
+      const side = placement.split("-")[0];
+      this.floatUiViewRef.nativeElement.setAttribute(
+        "data-float-ui-placement",
+        side
+      );
+      if (middlewareData.arrow) {
+        const staticSide = {
+          top: "bottom",
+          right: "left",
+          bottom: "top",
+          left: "right",
+        }[side];
+        Object.assign(arrowElement.style, {
+          left:
+            middlewareData.arrow.x != null ? `${middlewareData.arrow.x}px` : "",
+          top:
+            middlewareData.arrow.y != null ? `${middlewareData.arrow.y}px` : "",
+          [staticSide]: `${-arrowLen / 2}px`,
+        });
+      }
+      Object.assign(this.floatUiViewRef.nativeElement.style, {
+        left: `${x}px`,
+        top: `${y}px`,
+      });
+      this.toggleVisibility(!0);
+      this.onUpdate?.();
+    });
+  }
 
-    protected _createArrowSelector(): string {
-        return `div#${this.id}.float-ui-container > .float-ui-arrow.ngxp__force-arrow`;
+  protected _createArrowSelector(): string {
+    return `div#${this.id}.float-ui-container > .float-ui-arrow.ngxp__force-arrow`;
+  }
+
+  protected _determineArrowColor() {
+    if (!this.floatUiOptions.styles || this.arrowColor) {
+      return !1;
     }
-
-    protected _determineArrowColor() {
-        if (!this.floatUiOptions.styles || this.arrowColor) {
-
-            return !1;
-        }
-        const ruleValue = this.floatUiOptions.styles["background-color"] || this.floatUiOptions.styles.backgroundColor;
-        if (this.arrowColor === ruleValue) {
-            return !1;
-        }
-        this.arrowColor = ruleValue;
-        let $style = document.querySelector(`#${this._styleId}`) as HTMLStyleElement;
-        const styleContent = this.arrowColor ?
-            `${this._createArrowSelector()}:before { background-color: ${this.arrowColor}; }` : "";
-        if (!$style) {
-            $style = document.createElement("style") as HTMLStyleElement;
-            $style.id = this._styleId;
-            $style.setAttribute("type", "text/css");
-            document.head.appendChild($style);
-        }
-        // tslint:disable-next-line:no-string-literal
-        if ($style["styleSheet"]) {
-            // tslint:disable-next-line:no-string-literal
-            $style["styleSheet"].cssText = styleContent;
-            // This is required for IE8 and below.
-        }
-        else {
-            $style.innerHTML = styleContent;
-        }
+    const ruleValue =
+      this.floatUiOptions.styles["background-color"] ||
+      this.floatUiOptions.styles.backgroundColor;
+    if (this.arrowColor === ruleValue) {
+      return !1;
     }
-
-    protected _toggleVisibility(state): void {
-        this.displayType = ["none", "block"][+state];
-        this.opacity = +state;
-        this.ariaHidden = `${!state}`;
-        this.state = state;
+    this.arrowColor = ruleValue;
+    let $style = document.querySelector(
+      `#${this._styleId}`
+    ) as HTMLStyleElement;
+    const styleContent = this.arrowColor
+      ? `${this._createArrowSelector()}:before { background-color: ${
+          this.arrowColor
+        }; }`
+      : "";
+    if (!$style) {
+      $style = document.createElement("style") as HTMLStyleElement;
+      $style.id = this._styleId;
+      $style.setAttribute("type", "text/css");
+      document.head.appendChild($style);
     }
+    // tslint:disable-next-line:no-string-literal
+    if ($style["styleSheet"]) {
+      // tslint:disable-next-line:no-string-literal
+      $style["styleSheet"].cssText = styleContent;
+      // This is required for IE8 and below.
+    } else {
+      $style.innerHTML = styleContent;
+    }
+  }
+
+  protected _toggleVisibility(state): void {
+    this.displayType = ["none", "block"][+state];
+    this.opacity = +state;
+    this.ariaHidden = `${!state}`;
+    this.state = state;
+  }
 }

--- a/projects/ngx-float-ui/src/lib/directives/ngx-float-ui/ngx-float-ui.directive.ts
+++ b/projects/ngx-float-ui/src/lib/directives/ngx-float-ui/ngx-float-ui.directive.ts
@@ -1,15 +1,15 @@
 import {
-    ChangeDetectorRef,
-    ComponentRef,
-    Directive,
-    ElementRef,
-    EventEmitter,
-    Inject,
-    Input,
-    OnDestroy,
-    OnInit,
-    Output,
-    ViewContainerRef
+  ChangeDetectorRef,
+  ComponentRef,
+  Directive,
+  ElementRef,
+  EventEmitter,
+  Inject,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+  ViewContainerRef,
 } from "@angular/core";
 import {NgxFloatUiContentComponent} from "../../components/ngx-float-ui-content/ngx-float-ui-content.component";
 import {NgxFloatUiOptions} from "../../models/ngx-float-ui-options.model";
@@ -21,470 +21,519 @@ import {NgxFloatUiUtils} from "../../models/ngx-float-ui-utils.class";
 import {fromEvent, Subject, takeUntil, timer} from "rxjs";
 
 @Directive({
-    selector: "[floatUi]",
-    exportAs: "floatUi",
-    standalone: true
+  selector: "[floatUi]",
+  exportAs: "floatUi",
+  standalone: true,
 })
 export class NgxFloatUiDirective implements OnInit, OnDestroy {
+  static baseOptions: NgxFloatUiOptions = {
+    showDelay: 0,
+    hideOnClickOutside: true,
+    hideOnMouseLeave: false,
+    hideOnScroll: false,
+    appendTo: undefined,
+    ariaRole: "popper",
+    ariaDescribe: "",
+    styles: {},
+    showTrigger: "click",
+  };
 
-    static baseOptions: NgxFloatUiOptions = {
-        showDelay: 0,
-        hideOnClickOutside: true,
-        hideOnMouseLeave: false,
-        hideOnScroll: false,
-        appendTo: undefined,
-        ariaRole: "popper",
-        ariaDescribe: "",
-        styles: {},
-        trigger: NgxFloatUiTriggers.click
+  @Input()
+  set applyClass(newValue: string) {
+    if (newValue === this._applyClass) {
+      return;
+    }
+    this._applyClass = newValue;
+    this._checkExisting("applyClass", newValue);
+  }
+
+  get applyClass(): string {
+    return this._applyClass;
+  }
+
+  @Input()
+  set arrowClass(newValue: string) {
+    if (newValue === this._arrowClass) {
+      return;
+    }
+    this._arrowClass = newValue;
+    if (this._content) {
+      this._content.floatUiOptions.applyArrowClass = newValue;
+      if (!this._shown) {
+        return;
+      }
+      this._content.update();
+    }
+  }
+
+  get arrowClass(): string {
+    return this._arrowClass;
+  }
+
+  @Input()
+  set disabled(newValue: boolean) {
+    if (newValue === this._disabled) {
+      return;
+    }
+    this._disabled = !!newValue;
+    if (this._shown) {
+      this.hide();
+    }
+  }
+
+  get disabled(): boolean {
+    return this._disabled;
+  }
+
+  @Input()
+  set floatUi(newValue: string | NgxFloatUiContentComponent) {
+    if (newValue === this._floatUi) {
+      return;
+    }
+    this._floatUi = newValue;
+    if (this._content) {
+      if (typeof newValue === "string") {
+        this._content.text = newValue;
+      } else {
+        this._content = newValue;
+      }
+    }
+  }
+
+  get floatUi(): string | NgxFloatUiContentComponent {
+    return this._floatUi;
+  }
+
+  @Input()
+  set hideOnClickOutside(newValue: boolean | string) {
+    this._hideOnClickOutside = NgxFloatUiUtils.coerceBooleanProperty(newValue);
+  }
+
+  get hideOnClickOutside(): boolean {
+    return this._hideOnClickOutside;
+  }
+
+  @Input()
+  set placement(newValue: NgxFloatUiPlacements) {
+    this._placement = newValue;
+    this._checkExisting("placement", newValue);
+  }
+
+  get placement(): NgxFloatUiPlacements {
+    return this._placement;
+  }
+
+  @Input()
+  set preventOverflow(newValue: boolean) {
+    this._preventOverflow = NgxFloatUiUtils.coerceBooleanProperty(newValue);
+    this._checkExisting("preventOverflow", this._preventOverflow);
+  }
+
+  get preventOverflow(): boolean {
+    return this._preventOverflow;
+  }
+
+  @Input()
+  set showOnStart(newValue: boolean) {
+    this._showOnStart = NgxFloatUiUtils.coerceBooleanProperty(newValue);
+  }
+
+  get showOnStart(): boolean {
+    return this._showOnStart;
+  }
+
+  @Input()
+  appendTo: string;
+
+  @Input()
+  ariaDescribe: string | void;
+
+  @Input()
+  ariaRole: string | void;
+
+  @Input()
+  boundariesElement: string;
+
+  @Input()
+  disableAnimation: boolean;
+
+  @Input()
+  disableStyle: boolean;
+
+  @Input()
+  hideOnMouseLeave: boolean | void;
+
+  @Input()
+  hideOnScroll: boolean | void;
+
+  @Input()
+  hideTimeout: number = 0;
+
+  @Output()
+  onHidden: EventEmitter<NgxFloatUiDirective> =
+    new EventEmitter<NgxFloatUiDirective>();
+
+  @Output()
+  onShown: EventEmitter<NgxFloatUiDirective> =
+    new EventEmitter<NgxFloatUiDirective>();
+
+  @Output()
+  onUpdate: EventEmitter<void> = new EventEmitter<void>();
+
+  @Input()
+  positionFixed: boolean;
+
+  @Input()
+  showDelay: number | undefined;
+
+  @Input()
+  showTrigger: NgxFloatUiTriggers | undefined;
+
+  @Input()
+  styles: object;
+
+  @Input()
+  targetElement: HTMLElement;
+
+  @Input()
+  timeoutAfterShow: number = 0;
+
+  protected _applyClass: string;
+  protected _arrowClass: string;
+  protected _content: NgxFloatUiContentComponent;
+  protected _contentClass = NgxFloatUiContentComponent;
+  protected _contentRef: ComponentRef<NgxFloatUiContentComponent>;
+  protected _destroy$: Subject<void> = new Subject<void>();
+  protected _disabled: boolean;
+  protected _floatUi: string | NgxFloatUiContentComponent;
+  protected _globalEventListenersCtrl$: Subject<void> = new Subject<void>();
+  protected _hideOnClickOutside: boolean = !0;
+  protected _placement: NgxFloatUiPlacements;
+  protected _preventOverflow: boolean;
+  protected _scheduledHideTimeoutCtrl$: Subject<void> = new Subject<void>();
+  protected _scheduledShowTimeoutCtrl$: Subject<void> = new Subject<void>();
+  protected _shown: boolean = !1;
+  protected _showOnStart: boolean = !1;
+
+  constructor(
+    protected _changeDetectorRef: ChangeDetectorRef,
+    protected _elementRef: ElementRef,
+    protected _vcr: ViewContainerRef,
+    @Inject(NGX_FLOAT_UI_DEFAULTS)
+    protected _popperDefaults: NgxFloatUiOptions = {}
+  ) {
+    NgxFloatUiDirective.baseOptions = {
+      ...NgxFloatUiDirective.baseOptions,
+      ...this._popperDefaults,
     };
+  }
 
-    @Input()
-    set applyClass(newValue: string) {
-        if (newValue === this._applyClass) {
-            return;
+  static assignDefined(target: any, ...sources: any[]) {
+    for (const source of sources) {
+      for (const key of Object.keys(source)) {
+        const val = source[key];
+        if (val !== undefined) {
+          target[key] = val;
         }
-        this._applyClass = newValue;
-        this._checkExisting("applyClass", newValue);
+      }
     }
 
-    get applyClass(): string {
-        return this._applyClass;
-    }
-
-    @Input()
-    set arrowClass(newValue: string) {
-        if (newValue === this._arrowClass) {
-            return;
-        }
-        this._arrowClass = newValue;
-        if (this._content) {
-            this._content.floatUiOptions.applyArrowClass = newValue;
-            if (!this._shown) {
-                return;
-            }
-            this._content.update();
-        }
-    }
-
-    get arrowClass(): string {
-        return this._arrowClass;
-    }
-
-    @Input()
-    set disabled(newValue: boolean) {
-        if (newValue === this._disabled) {
-            return;
-        }
-        this._disabled = !!newValue;
-        if (this._shown) {
-            this.hide();
-        }
-    }
-
-    get disabled(): boolean {
-        return this._disabled;
-    }
-
-    @Input()
-    set floatUi(newValue: string | NgxFloatUiContentComponent) {
-        if (newValue === this._floatUi) {
-
-            return;
-        }
-        this._floatUi = newValue;
-        if (this._content) {
-            if (typeof newValue === "string") {
-                this._content.text = newValue;
-            }
-            else {
-                this._content = newValue;
-            }
-        }
-    }
-
-    get floatUi(): string | NgxFloatUiContentComponent {
-        return this._floatUi;
-    }
-
-    @Input()
-    set hideOnClickOutside(newValue: boolean | string) {
-        this._hideOnClickOutside = NgxFloatUiUtils.coerceBooleanProperty(newValue);
-    }
-
-    get hideOnClickOutside(): boolean {
-        return this._hideOnClickOutside;
-    }
-
-    @Input()
-    set placement(newValue: NgxFloatUiPlacements) {
-        this._placement = newValue;
-        this._checkExisting("placement", newValue);
-    }
-
-    get placement(): NgxFloatUiPlacements {
-
-        return this._placement;
-    }
-
-    @Input()
-    set preventOverflow(newValue: boolean) {
-        this._preventOverflow = NgxFloatUiUtils.coerceBooleanProperty(newValue);
-        this._checkExisting("preventOverflow", this._preventOverflow);
-    }
-
-    get preventOverflow(): boolean {
-        return this._preventOverflow;
-    }
-
-    @Input()
-    set showOnStart(newValue: boolean) {
-        this._showOnStart = NgxFloatUiUtils.coerceBooleanProperty(newValue);
-    }
-
-    get showOnStart(): boolean {
-        return this._showOnStart;
-    }
-
-    @Input()
-    appendTo: string;
-
-    @Input()
-    ariaDescribe: string | void;
-
-    @Input()
-    ariaRole: string | void;
-
-    @Input()
-    boundariesElement: string;
-
-    @Input()
-    disableAnimation: boolean;
-
-    @Input()
-    disableStyle: boolean;
-
-    @Input()
-    hideOnMouseLeave: boolean | void;
-
-    @Input()
-    hideOnScroll: boolean | void;
-
-    @Input()
-    hideTimeout: number = 0;
-
-    @Output()
-    onHidden: EventEmitter<NgxFloatUiDirective> = new EventEmitter<NgxFloatUiDirective>();
-
-    @Output()
-    onShown: EventEmitter<NgxFloatUiDirective> = new EventEmitter<NgxFloatUiDirective>();
-
-    @Output()
-    onUpdate: EventEmitter<void> = new EventEmitter<void>();
-
-    @Input()
-    positionFixed: boolean;
-
-    @Input()
-    showDelay: number | undefined;
-
-    @Input()
-    showTrigger: NgxFloatUiTriggers | undefined;
-
-    @Input()
-    styles: object;
-
-    @Input()
-    targetElement: HTMLElement;
-
-    @Input()
-    timeoutAfterShow: number = 0;
-
-    protected _applyClass: string;
-    protected _arrowClass: string;
-    protected _content: NgxFloatUiContentComponent;
-    protected _contentClass = NgxFloatUiContentComponent;
-    protected _contentRef: ComponentRef<NgxFloatUiContentComponent>;
-    protected _destroy$: Subject<void> = new Subject<void>();
-    protected _disabled: boolean;
-    protected _floatUi: string | NgxFloatUiContentComponent;
-    protected _globalEventListenersCtrl$: Subject<void> = new Subject<void>();
-    protected _hideOnClickOutside: boolean = !0;
-    protected _placement: NgxFloatUiPlacements;
-    protected _preventOverflow: boolean;
-    protected _scheduledHideTimeoutCtrl$: Subject<void> = new Subject<void>();
-    protected _scheduledShowTimeoutCtrl$: Subject<void> = new Subject<void>();
-    protected _shown: boolean = !1;
-    protected _showOnStart: boolean = !1;
-
-    constructor(protected _changeDetectorRef: ChangeDetectorRef,
-                protected _elementRef: ElementRef,
-                protected _vcr: ViewContainerRef,
-                @Inject(NGX_FLOAT_UI_DEFAULTS) protected _popperDefaults: NgxFloatUiOptions = {}) {
-        NgxFloatUiDirective.baseOptions = {...NgxFloatUiDirective.baseOptions, ...this._popperDefaults};
-    }
-
-    static assignDefined(target: any, ...sources: any[]) {
-        for (const source of sources) {
-            for (const key of Object.keys(source)) {
-                const val = source[key];
-                if (val !== undefined) {
-                    target[key] = val;
-                }
-            }
-        }
-
-        return target;
-    }
-
-    applyTriggerListeners() {
-        switch (this.showTrigger) {
-            case NgxFloatUiTriggers.click:
-                this._addListener("click", this.toggle.bind(this));
-                break;
-            case NgxFloatUiTriggers.mousedown:
-                this._addListener("mousedown", this.toggle.bind(this));
-                break;
-            case NgxFloatUiTriggers.hover:
-                this._addListener("mouseenter", this.scheduledShow.bind(this, this.showDelay));
-                ["touchend", "touchcancel", "mouseleave"].forEach((eventName) => {
-                    this._addListener(eventName, this.scheduledHide.bind(this, null, this.hideTimeout));
-                });
-                break;
-        }
-        if (this.showTrigger !== NgxFloatUiTriggers.hover && this.hideOnMouseLeave) {
-            ["touchend", "touchcancel", "mouseleave"].forEach((eventName) => {
-                this._addListener(eventName, this.scheduledHide.bind(this, null, this.hideTimeout));
-            });
-        }
-    }
-
-    getRefElement() {
-        return this.targetElement || this._elementRef.nativeElement;
-    }
-
-    hide() {
-        if (this.disabled) {
-            return;
-        }
-        if (!this._shown) {
-            this._scheduledShowTimeoutCtrl$.next();
-
-            return;
-        }
-
-        this._shown = false;
-        if (this._contentRef) {
-            this._contentRef.instance.hide();
-        }
-        else {
-            this._content.hide();
-        }
-        this.onHidden.emit(this);
-        this._globalEventListenersCtrl$.next();
-    }
-
-    hideOnClickOutsideHandler($event: MouseEvent): void {
-        if (this.disabled || !this.hideOnClickOutside || $event.target === this._content.elRef.nativeElement ||
-            this._content.elRef.nativeElement.contains($event.target)) {
-            return;
-        }
-        this.scheduledHide($event, this.hideTimeout);
-    }
-
-    hideOnScrollHandler($event: MouseEvent): void {
-        if (this.disabled || !this.hideOnScroll) {
-            return;
-        }
-        this.scheduledHide($event, this.hideTimeout);
-    }
-
-    ngOnDestroy() {
-        this._destroy$.next();
-        this._destroy$.complete();
-        this._content && this._content.clean();
-    }
-
-    ngOnInit() {
-        if (typeof this.floatUi === "string") {
-            this._content = this._constructContent();
-            this._content.text = this.floatUi;
-        }
-        else if (typeof this.floatUi === typeof void 0) {
-            this._content = this._constructContent();
-            this._content.text = "";
-        }
-        else {
-            this._content = this.floatUi;
-        }
-        const popperRef = this._content;
-        popperRef.referenceObject = this.getRefElement();
-        this._setContentProperties(popperRef);
-        this._setDefaults();
-        this.applyTriggerListeners();
-        if (this.showOnStart) {
-            this.scheduledShow();
-        }
-    }
-
-    scheduledHide($event: any = null, delay: number = this.hideTimeout) {
-        if (this.disabled) {
-            return;
-        }
-        this._scheduledShowTimeoutCtrl$.next();
-        timer(delay)
-            .pipe(takeUntil(this._scheduledHideTimeoutCtrl$), takeUntil(this._destroy$))
-            .subscribe({
-                next: () => {
-                    // TODO: check
-                    const toElement = $event ? $event.toElement : null;
-                    const popperContentView = this._content.floatUiViewRef ? this._content.floatUiViewRef.nativeElement : false;
-                    if (!popperContentView ||
-                        popperContentView === toElement ||
-                        popperContentView.contains(toElement) ||
-                        (this.floatUi && (this.floatUi as NgxFloatUiContentComponent).isMouseOver)) {
-
-                        return;
-                    }
-                    this.hide();
-                    this._applyChanges();
-                }
-            });
-    }
-
-    scheduledShow(delay: number = this.showDelay) {
-        if (this.disabled) {
-            return;
-        }
-        this._scheduledHideTimeoutCtrl$.next();
-        timer(delay)
-            .pipe(takeUntil(this._scheduledShowTimeoutCtrl$), takeUntil(this._destroy$))
-            .subscribe({
-                next: () => {
-                    this.show();
-                    this._applyChanges();
-                }
-            });
-    }
-
-    show() {
-        if (this._shown) {
-            this._scheduledHideTimeoutCtrl$.next();
-
-            return;
-        }
-
-        this._shown = true;
-        const popperRef = this._content;
-        const element = this.getRefElement();
-        if (popperRef.referenceObject !== element) {
-            popperRef.referenceObject = element;
-        }
-        this._setContentProperties(popperRef);
-        popperRef.show();
-        this.onShown.emit(this);
-        if (this.timeoutAfterShow > 0) {
-            this.scheduledHide(null, this.timeoutAfterShow);
-        }
-        fromEvent(document, "click")
-            .pipe(takeUntil(this._globalEventListenersCtrl$), takeUntil(this._destroy$))
-            .subscribe({
-                next: (e: MouseEvent) => this.hideOnClickOutsideHandler(e)
-            });
-        fromEvent(this._getScrollParent(this.getRefElement()), "scroll")
-            .pipe(takeUntil(this._globalEventListenersCtrl$), takeUntil(this._destroy$))
-            .subscribe({
-                next: (e: MouseEvent) => {
-                    this.hideOnScrollHandler(e);
-                }
-            });
-    }
-
-    toggle() {
-        if (this.disabled) {
-            return;
-        }
-        this._shown ? this.scheduledHide(null, this.hideTimeout) : this.scheduledShow();
-    }
-
-    protected _addListener(eventName: string, cb: () => void): void {
-        fromEvent(this._elementRef.nativeElement, eventName)
-            .pipe(takeUntil(this._destroy$))
-            .subscribe({
-                next: cb
-            });
-    }
-
-    protected _applyChanges() {
-        this._changeDetectorRef.markForCheck();
-        this._changeDetectorRef.detectChanges();
-    }
-
-    protected _checkExisting(key: string, newValue: string | number | boolean | NgxFloatUiPlacements): void {
-        if (this._content) {
-            this._content.floatUiOptions[key] = newValue;
-            if (!this._shown) {
-                return;
-            }
-            this._content.update();
-        }
-    }
-
-    protected _constructContent(): NgxFloatUiContentComponent {
-        this._contentRef = this._vcr.createComponent(this._contentClass);
-
-        return this._contentRef.instance as NgxFloatUiContentComponent;
-    }
-
-    protected _getScrollParent(node) {
-        const isElement = node instanceof HTMLElement;
-        const overflowY = isElement && window.getComputedStyle(node).overflowY;
-        const isScrollable = overflowY !== "visible" && overflowY !== "hidden";
-
-        if (!node) {
-            return null;
-        }
-        else if (isScrollable && node.scrollHeight > node.clientHeight) {
-            return node;
-        }
-
-        return this._getScrollParent(node.parentNode) || document;
-    }
-
-    protected _onPopperUpdate() {
-        this.onUpdate.emit();
-    }
-
-    protected _setContentProperties(popperRef: NgxFloatUiContentComponent) {
-        popperRef.floatUiOptions = NgxFloatUiDirective.assignDefined(popperRef.floatUiOptions, NgxFloatUiDirective.baseOptions, {
-            showDelay: this.showDelay,
-            disableAnimation: this.disableAnimation,
-            disableDefaultStyling: this.disableStyle,
-            placement: this.placement,
-            boundariesElement: this.boundariesElement,
-            trigger: this.showTrigger,
-            positionFixed: this.positionFixed,
-            ariaDescribe: this.ariaDescribe,
-            ariaRole: this.ariaRole,
-            applyClass: this.applyClass,
-            applyArrowClass: this.arrowClass,
-            hideOnMouseLeave: this.hideOnMouseLeave,
-            styles: this.styles,
-            appendTo: this.appendTo,
-            preventOverflow: this.preventOverflow,
+    return target;
+  }
+
+  applyTriggerListeners() {
+    switch (this.showTrigger) {
+      case "click":
+        this._addListener("click", this.toggle.bind(this));
+        break;
+      case "mousedown":
+        this._addListener("mousedown", this.toggle.bind(this));
+        break;
+      case "hover":
+        this._addListener(
+          "mouseenter",
+          this.scheduledShow.bind(this, this.showDelay)
+        );
+        ["touchend", "touchcancel", "mouseleave"].forEach((eventName) => {
+          this._addListener(
+            eventName,
+            this.scheduledHide.bind(this, null, this.hideTimeout)
+          );
         });
-        popperRef.onUpdate = this._onPopperUpdate.bind(this);
-        popperRef.onHidden
-            .pipe(takeUntil(this._destroy$))
-            .subscribe(this.hide.bind(this));
+        break;
+    }
+    if (this.showTrigger !== "hover" && this.hideOnMouseLeave) {
+      ["touchend", "touchcancel", "mouseleave"].forEach((eventName) => {
+        this._addListener(
+          eventName,
+          this.scheduledHide.bind(this, null, this.hideTimeout)
+        );
+      });
+    }
+  }
+
+  getRefElement() {
+    return this.targetElement || this._elementRef.nativeElement;
+  }
+
+  hide() {
+    if (this.disabled) {
+      return;
+    }
+    if (!this._shown) {
+      this._scheduledShowTimeoutCtrl$.next();
+
+      return;
     }
 
-    protected _setDefaults() {
-        ["showDelay", "hideOnScroll", "hideOnMouseLeave", "hideOnClickOutside", "ariaRole", "ariaDescribe"].forEach((key) => {
-            this[key] = this[key] === void 0 ? NgxFloatUiDirective.baseOptions[key] : this[key];
-        });
-        this.showTrigger = this.showTrigger || NgxFloatUiDirective.baseOptions.trigger;
-        this.styles = this.styles === void 0 ? {...NgxFloatUiDirective.baseOptions.styles} : this.styles;
+    this._shown = false;
+    if (this._contentRef) {
+      this._contentRef.instance.hide();
+    } else {
+      this._content.hide();
+    }
+    this.onHidden.emit(this);
+    this._globalEventListenersCtrl$.next();
+  }
+
+  hideOnClickOutsideHandler($event: MouseEvent): void {
+    if (
+      this.disabled ||
+      !this.hideOnClickOutside ||
+      $event.target === this._content.elRef.nativeElement ||
+      this._content.elRef.nativeElement.contains($event.target)
+    ) {
+      return;
+    }
+    this.scheduledHide($event, this.hideTimeout);
+  }
+
+  hideOnScrollHandler($event: MouseEvent): void {
+    if (this.disabled || !this.hideOnScroll) {
+      return;
+    }
+    this.scheduledHide($event, this.hideTimeout);
+  }
+
+  ngOnDestroy() {
+    this._destroy$.next();
+    this._destroy$.complete();
+    this._content && this._content.clean();
+  }
+
+  ngOnInit() {
+    if (typeof this.floatUi === "string") {
+      this._content = this._constructContent();
+      this._content.text = this.floatUi;
+    } else if (typeof this.floatUi === typeof void 0) {
+      this._content = this._constructContent();
+      this._content.text = "";
+    } else {
+      this._content = this.floatUi;
+    }
+    const popperRef = this._content;
+    popperRef.referenceObject = this.getRefElement();
+    this._setContentProperties(popperRef);
+    this._setDefaults();
+    this.applyTriggerListeners();
+    if (this.showOnStart) {
+      this.scheduledShow();
+    }
+  }
+
+  scheduledHide($event: any = null, delay: number = this.hideTimeout) {
+    if (this.disabled) {
+      return;
+    }
+    this._scheduledShowTimeoutCtrl$.next();
+    timer(delay)
+      .pipe(
+        takeUntil(this._scheduledHideTimeoutCtrl$),
+        takeUntil(this._destroy$)
+      )
+      .subscribe({
+        next: () => {
+          // TODO: check
+          const toElement = $event ? $event.toElement : null;
+          const popperContentView = this._content.floatUiViewRef
+            ? this._content.floatUiViewRef.nativeElement
+            : false;
+          if (
+            !popperContentView ||
+            popperContentView === toElement ||
+            popperContentView.contains(toElement) ||
+            (this.floatUi &&
+              (this.floatUi as NgxFloatUiContentComponent).isMouseOver)
+          ) {
+            return;
+          }
+          this.hide();
+          this._applyChanges();
+        },
+      });
+  }
+
+  scheduledShow(delay: number = this.showDelay) {
+    if (this.disabled) {
+      return;
+    }
+    this._scheduledHideTimeoutCtrl$.next();
+    timer(delay)
+      .pipe(
+        takeUntil(this._scheduledShowTimeoutCtrl$),
+        takeUntil(this._destroy$)
+      )
+      .subscribe({
+        next: () => {
+          this.show();
+          this._applyChanges();
+        },
+      });
+  }
+
+  show() {
+    if (this._shown) {
+      this._scheduledHideTimeoutCtrl$.next();
+
+      return;
     }
 
+    this._shown = true;
+    const popperRef = this._content;
+    const element = this.getRefElement();
+    if (popperRef.referenceObject !== element) {
+      popperRef.referenceObject = element;
+    }
+    this._setContentProperties(popperRef);
+    popperRef.show();
+    this.onShown.emit(this);
+    if (this.timeoutAfterShow > 0) {
+      this.scheduledHide(null, this.timeoutAfterShow);
+    }
+    fromEvent(document, "click")
+      .pipe(
+        takeUntil(this._globalEventListenersCtrl$),
+        takeUntil(this._destroy$)
+      )
+      .subscribe({
+        next: (e: MouseEvent) => this.hideOnClickOutsideHandler(e),
+      });
+    fromEvent(this._getScrollParent(this.getRefElement()), "scroll")
+      .pipe(
+        takeUntil(this._globalEventListenersCtrl$),
+        takeUntil(this._destroy$)
+      )
+      .subscribe({
+        next: (e: MouseEvent) => {
+          this.hideOnScrollHandler(e);
+        },
+      });
+  }
+
+  toggle() {
+    if (this.disabled) {
+      return;
+    }
+    this._shown
+      ? this.scheduledHide(null, this.hideTimeout)
+      : this.scheduledShow();
+  }
+
+  protected _addListener(eventName: string, cb: () => void): void {
+    fromEvent(this._elementRef.nativeElement, eventName)
+      .pipe(takeUntil(this._destroy$))
+      .subscribe({
+        next: cb,
+      });
+  }
+
+  protected _applyChanges() {
+    this._changeDetectorRef.markForCheck();
+    this._changeDetectorRef.detectChanges();
+  }
+
+  protected _checkExisting(
+    key: string,
+    newValue: string | number | boolean | NgxFloatUiPlacements
+  ): void {
+    if (this._content) {
+      this._content.floatUiOptions[key] = newValue;
+      if (!this._shown) {
+        return;
+      }
+      this._content.update();
+    }
+  }
+
+  protected _constructContent(): NgxFloatUiContentComponent {
+    this._contentRef = this._vcr.createComponent(this._contentClass);
+
+    return this._contentRef.instance as NgxFloatUiContentComponent;
+  }
+
+  protected _getScrollParent(node) {
+    const isElement = node instanceof HTMLElement;
+    const overflowY = isElement && window.getComputedStyle(node).overflowY;
+    const isScrollable = overflowY !== "visible" && overflowY !== "hidden";
+
+    if (!node) {
+      return null;
+    } else if (isScrollable && node.scrollHeight > node.clientHeight) {
+      return node;
+    }
+
+    return this._getScrollParent(node.parentNode) || document;
+  }
+
+  protected _onPopperUpdate() {
+    this.onUpdate.emit();
+  }
+
+  protected _setContentProperties(popperRef: NgxFloatUiContentComponent) {
+    popperRef.floatUiOptions = NgxFloatUiDirective.assignDefined(
+      popperRef.floatUiOptions,
+      NgxFloatUiDirective.baseOptions,
+      {
+        showDelay: this.showDelay,
+        disableAnimation: this.disableAnimation,
+        disableDefaultStyling: this.disableStyle,
+        placement: this.placement,
+        boundariesElement: this.boundariesElement,
+        trigger: this.showTrigger,
+        positionFixed: this.positionFixed,
+        ariaDescribe: this.ariaDescribe,
+        ariaRole: this.ariaRole,
+        applyClass: this.applyClass,
+        applyArrowClass: this.arrowClass,
+        hideOnMouseLeave: this.hideOnMouseLeave,
+        styles: this.styles,
+        appendTo: this.appendTo,
+        preventOverflow: this.preventOverflow,
+      }
+    );
+    popperRef.onUpdate = this._onPopperUpdate.bind(this);
+    popperRef.onHidden
+      .pipe(takeUntil(this._destroy$))
+      .subscribe(this.hide.bind(this));
+  }
+
+  protected _setDefaults() {
+    [
+      "showDelay",
+      "hideOnScroll",
+      "hideOnMouseLeave",
+      "hideOnClickOutside",
+      "ariaRole",
+      "ariaDescribe",
+    ].forEach((key) => {
+      this[key] =
+        this[key] === void 0 ? NgxFloatUiDirective.baseOptions[key] : this[key];
+    });
+    this.showTrigger =
+      this.showTrigger || NgxFloatUiDirective.baseOptions.showTrigger;
+    this.styles =
+      this.styles === void 0
+        ? {...NgxFloatUiDirective.baseOptions.styles}
+        : this.styles;
+  }
 }

--- a/projects/ngx-float-ui/src/lib/models/ngx-float-ui-options.model.ts
+++ b/projects/ngx-float-ui/src/lib/models/ngx-float-ui-options.model.ts
@@ -2,23 +2,23 @@ import {NgxFloatUiTriggers} from "./ngx-float-ui-triggers.model";
 import {NgxFloatUiPlacements} from "./ngx-float-ui-placements.model";
 
 export interface NgxFloatUiOptions {
-    appendTo?: string;
-    applyArrowClass?: string;
-    applyClass?: string;
-    ariaDescribe?: string;
-    ariaRole?: string;
-    boundariesElement?: string;
-    disableAnimation?: boolean;
-    disableDefaultStyling?: boolean;
-    hideOnClickOutside?: boolean;
-    hideOnMouseLeave?: boolean;
-    hideOnScroll?: boolean;
-    placement?: NgxFloatUiPlacements;
-    positionFixed?: boolean;
-    preventOverflow?: boolean;
-    showDelay?: number;
-    styles?: { [key: string]: string };
-    trigger?: NgxFloatUiTriggers;
+  appendTo?: string;
+  applyArrowClass?: string;
+  applyClass?: string;
+  ariaDescribe?: string;
+  ariaRole?: string;
+  boundariesElement?: string;
+  disableAnimation?: boolean;
+  disableDefaultStyling?: boolean;
+  hideOnClickOutside?: boolean;
+  hideOnMouseLeave?: boolean;
+  hideOnScroll?: boolean;
+  placement?: NgxFloatUiPlacements;
+  positionFixed?: boolean;
+  preventOverflow?: boolean;
+  showDelay?: number;
+  styles?: {[key: string]: string};
+  showTrigger?: NgxFloatUiTriggers;
 }
 
 export type NgxFloatUiOptionsKey = keyof NgxFloatUiOptions;

--- a/projects/ngx-float-ui/src/lib/models/ngx-float-ui-triggers.model.ts
+++ b/projects/ngx-float-ui/src/lib/models/ngx-float-ui-triggers.model.ts
@@ -1,6 +1,1 @@
-export enum NgxFloatUiTriggers {
-  click = "click",
-  hover = "hover",
-  mousedown = "mousedown",
-  none = "none"
-}
+export type NgxFloatUiTriggers = "click" | "mousedown" | "hover" | "none";


### PR DESCRIPTION
This is just an untested proposal to review some design choices, feel free to close it or reply with your choice, so I can make a tested PR
1. to add more consistency I've renamed `trigger` to `showTrigger` in module's config (as in template config).
2. enums are inconvenient in template. For design you have to add `NgxFloatUiTriggers` do something like.

```typescript
    import {  NgxFloatUiTriggers } from 'ngx-float-ui';
    triggerHover = NgxFloatUiTriggers.hover;

..................
<div
    [showTrigger]="triggerHover"
></div>
```

vs using types where the type check is the same
```typescript
<div
    showTrigger="hover"
></div>
```

PS all README examples use `[trigger]` instead of `[showTrigger]`