### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,9 +225,6 @@ NgModule({
   | 'bottom-end'
   | 'left-end'
   | 'right-end'
-  | 'auto'
-  | 'auto-start'
-  | 'auto-end'
   
 11. NgxFloatUiTriggers:
 


### PR DESCRIPTION
Removed the values that are not present in the enum NgxFloatUiPopPlacements and also not supported by [floating-ui](https://floating-ui.com/docs/computeposition#placement): 'auto' | 'auto-start'  | 'auto-end'